### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -104,7 +104,7 @@ class Script(object):
 
         cache.clear_time_caches()
         debug.reset_time()
-        self._grammar = load_grammar('grammar%s.%s' % sys.version_info[:2])
+        self._grammar = load_grammar('grammar{0!s}.{1!s}'.format(*sys.version_info[:2]))
         self._user_context = UserContext(self.source, self._pos)
         self._parser = UserContextParser(self._grammar, self.source, path,
                                          self._pos, self._user_context,
@@ -127,7 +127,7 @@ class Script(object):
         return self.path
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__, repr(self._orig_path))
+        return '<{0!s}: {1!s}>'.format(self.__class__.__name__, repr(self._orig_path))
 
     def completions(self):
         """
@@ -696,7 +696,7 @@ def preload_module(*modules):
     :param modules: different module names, list of string.
     """
     for m in modules:
-        s = "import %s as x; x." % m
+        s = "import {0!s} as x; x.".format(m)
         Script(s, 1, len(s), None).completions()
 
 

--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -357,7 +357,7 @@ class BaseDefinition(object):
         return Definition(self._evaluator, scope.name)
 
     def __repr__(self):
-        return "<%s %s>" % (type(self).__name__, self.description)
+        return "<{0!s} {1!s}>".format(type(self).__name__, self.description)
 
 
 class Completion(BaseDefinition):
@@ -428,11 +428,11 @@ class Completion(BaseDefinition):
         else:
             desc = '.'.join(unicode(p) for p in self._path())
 
-        line = '' if self.in_builtin_module else '@%s' % self.line
-        return '%s: %s%s' % (t, desc, line)
+        line = '' if self.in_builtin_module else '@{0!s}'.format(self.line)
+        return '{0!s}: {1!s}{2!s}'.format(t, desc, line)
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self._name)
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, self._name)
 
     def docstring(self, raw=False, fast=True):
         """
@@ -552,7 +552,7 @@ class Definition(use_metaclass(CachedMetaClass, BaseDefinition)):
             d = 'def ' + unicode(d.name)
         elif isinstance(d, tree.Module):
             # only show module name
-            d = 'module %s' % self.module_name
+            d = 'module {0!s}'.format(self.module_name)
         elif isinstance(d, tree.Param):
             d = d.get_code().strip()
             if d.endswith(','):
@@ -586,8 +586,8 @@ class Definition(use_metaclass(CachedMetaClass, BaseDefinition)):
         .. todo:: Add full path. This function is should return a
             `module.class.function` path.
         """
-        position = '' if self.in_builtin_module else '@%s' % (self.line)
-        return "%s:%s%s" % (self.module_name, self.description, position)
+        position = '' if self.in_builtin_module else '@{0!s}'.format((self.line))
+        return "{0!s}:{1!s}{2!s}".format(self.module_name, self.description, position)
 
     @memoize_default()
     def defined_names(self):
@@ -689,7 +689,7 @@ class CallSignature(Definition):
         return self._executable.get_parent_until()
 
     def __repr__(self):
-        return '<%s: %s index %s>' % (type(self).__name__, self._name,
+        return '<{0!s}: {1!s} index {2!s}>'.format(type(self).__name__, self._name,
                                       self.index)
 
 

--- a/jedi/api/keywords.py
+++ b/jedi/api/keywords.py
@@ -84,7 +84,7 @@ class Keyword(object):
         return imitate_pydoc(self.name)
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self.name)
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, self.name)
 
 
 def imitate_pydoc(string):

--- a/jedi/api/replstartup.py
+++ b/jedi/api/replstartup.py
@@ -18,7 +18,7 @@ Then you will be able to use Jedi completer in your Python interpreter::
 import jedi.utils
 from jedi import __version__ as __jedi_version__
 
-print('REPL completion using Jedi %s' % __jedi_version__)
+print('REPL completion using Jedi {0!s}'.format(__jedi_version__))
 jedi.utils.setup_readline()
 
 del jedi

--- a/jedi/cache.py
+++ b/jedi/cache.py
@@ -240,7 +240,7 @@ class ParserPickling(object):
 
     def __init__(self):
         self.__index = None
-        self.py_tag = 'cpython-%s%s' % sys.version_info[:2]
+        self.py_tag = 'cpython-{0!s}{1!s}'.format(*sys.version_info[:2])
         """
         Short name for distinguish Python implementations and versions.
 
@@ -320,7 +320,7 @@ class ParserPickling(object):
         shutil.rmtree(self._cache_directory())
 
     def _get_hashed_path(self, path):
-        return self._get_path('%s.pkl' % hashlib.md5(path.encode("utf-8")).hexdigest())
+        return self._get_path('{0!s}.pkl'.format(hashlib.md5(path.encode("utf-8")).hexdigest()))
 
     def _get_path(self, file):
         dir = self._cache_directory()

--- a/jedi/debug.py
+++ b/jedi/debug.py
@@ -76,7 +76,7 @@ def speed(name):
     if debug_function and enable_speed:
         now = time.time()
         i = ' ' * _debug_indent
-        debug_function(SPEED, i + 'speed: ' + '%s %s' % (name, now - _start_time))
+        debug_function(SPEED, i + 'speed: ' + '{0!s} {1!s}'.format(name, now - _start_time))
 
 
 def print_to_stdout(level, str_out):

--- a/jedi/evaluate/__init__.py
+++ b/jedi/evaluate/__init__.py
@@ -261,8 +261,7 @@ class Evaluator(object):
                 try:
                     get = typ.get_index_types
                 except AttributeError:
-                    debug.warning("TypeError: '%s' object is not subscriptable"
-                                  % typ)
+                    debug.warning("TypeError: '{0!s}' object is not subscriptable".format(typ))
                 else:
                     new_types += get(self, node)
         return new_types

--- a/jedi/evaluate/analysis.py
+++ b/jedi/evaluate/analysis.py
@@ -45,7 +45,7 @@ class Error(object):
         return first + str(CODES[self.name][0])
 
     def __unicode__(self):
-        return '%s:%s:%s: %s %s' % (self.path, self.line, self.column,
+        return '{0!s}:{1!s}:{2!s}: {3!s} {4!s}'.format(self.path, self.line, self.column,
                                     self.code, self.message)
 
     def __str__(self):
@@ -62,7 +62,7 @@ class Error(object):
         return hash((self.path, self._start_pos, self.name))
 
     def __repr__(self):
-        return '<%s %s: %s@%s,%s>' % (self.__class__.__name__,
+        return '<{0!s} {1!s}: {2!s}@{3!s},{4!s}>'.format(self.__class__.__name__,
                                       self.name, self.path,
                                       self._start_pos[0], self._start_pos[1])
 
@@ -104,7 +104,7 @@ def _check_for_setattr(instance):
 
 
 def add_attribute_error(evaluator, scope, name):
-    message = ('AttributeError: %s has no attribute %s.' % (scope, name))
+    message = ('AttributeError: {0!s} has no attribute {1!s}.'.format(scope, name))
     from jedi.evaluate.representation import Instance
     # Check for __getattr__/__getattribute__ existance and issue a warning
     # instead of an error, if that happens.

--- a/jedi/evaluate/compiled/__init__.py
+++ b/jedi/evaluate/compiled/__init__.py
@@ -99,7 +99,7 @@ class CompiledObject(Base):
         return params
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, repr(self.obj))
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, repr(self.obj))
 
     @underscore_memoization
     def _parse_function_doc(self):
@@ -166,7 +166,7 @@ class CompiledObject(Base):
         if name in dir(self._cls().obj):
             return CompiledName(self._cls(), name).parent
         else:
-            raise KeyError("CompiledObject doesn't have an attribute '%s'." % name)
+            raise KeyError("CompiledObject doesn't have an attribute '{0!s}'.".format(name))
 
     def get_index_types(self, evaluator, index_array=()):
         # If the object doesn't have `__getitem__`, just raise the
@@ -262,7 +262,7 @@ class LazyNamesDict(object):
         try:
             getattr(self._compiled_obj.obj, name)
         except AttributeError:
-            raise KeyError('%s in %s not found.' % (name, self._compiled_obj))
+            raise KeyError('{0!s} in {1!s} not found.'.format(name, self._compiled_obj))
         return [CompiledName(self._compiled_obj, name)]
 
     def values(self):
@@ -293,7 +293,7 @@ class CompiledName(FakeName):
             name = self._obj.name  # __name__ is not defined all the time
         except AttributeError:
             name = None
-        return '<%s: (%s).%s>' % (type(self).__name__, name, self.name)
+        return '<{0!s}: ({1!s}).{2!s}>'.format(type(self).__name__, name, self.name)
 
     def is_definition(self):
         return True

--- a/jedi/evaluate/compiled/fake.py
+++ b/jedi/evaluate/compiled/fake.py
@@ -106,7 +106,7 @@ def get_faked(module, obj, name=None):
     else:
         # Set the docstr which was previously not set (faked modules don't
         # contain it).
-        doc = '"""%s"""' % obj.__doc__  # TODO need escapes.
+        doc = '"""{0!s}"""'.format(obj.__doc__)  # TODO need escapes.
         suite = result.children[-1]
         string = pt.String(pt.zero_position_modifier, doc, (0, 0), '')
         new_line = pt.Whitespace('\n', (0, 0), '')

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -125,7 +125,7 @@ def _evaluate_for_statement_string(evaluator, string, module):
     for element in re.findall('((?:\w+\.)*\w+)\.', string):
         # Try to import module part in dotted name.
         # (e.g., 'threading' in 'threading.Thread').
-        string = 'import %s\n' % element + string
+        string = 'import {0!s}\n'.format(element) + string
 
     # Take the default grammar here, if we load the Python 2.7 grammar here, it
     # will be impossible to use `...` (Ellipsis) as a token. Docstring types

--- a/jedi/evaluate/finder.py
+++ b/jedi/evaluate/finder.py
@@ -91,8 +91,7 @@ class NameFinder(object):
                          and isinstance(self.name_str.parent.parent, tree.Param)):
             if not isinstance(self.name_str, (str, unicode)):  # TODO Remove?
                 if search_global:
-                    message = ("NameError: name '%s' is not defined."
-                               % self.name_str)
+                    message = ("NameError: name '{0!s}' is not defined.".format(self.name_str))
                     analysis.add(self._evaluator, 'name-error', self.name_str,
                                  message)
                 else:

--- a/jedi/evaluate/flow_analysis.py
+++ b/jedi/evaluate/flow_analysis.py
@@ -24,7 +24,7 @@ class Status(object):
             return REACHABLE if self._value and other._value else UNREACHABLE
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self._name)
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, self._name)
 
 
 REACHABLE = Status(True, 'reachable')

--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -149,7 +149,7 @@ class NestedImportModule(tree.Module):
         return getattr(self._module, name)
 
     def __repr__(self):
-        return "<%s: %s of %s>" % (self.__class__.__name__, self._module,
+        return "<{0!s}: {1!s} of {2!s}>".format(self.__class__.__name__, self._module,
                                    self._nested_import)
 
 
@@ -185,7 +185,7 @@ class Importer(object):
 
         :param import_path: List of namespaces (strings or Names).
         """
-        debug.speed('import %s' % (import_path,))
+        debug.speed('import {0!s}'.format(import_path))
         self._evaluator = evaluator
         self.level = level
         self.module = module

--- a/jedi/evaluate/iterable.py
+++ b/jedi/evaluate/iterable.py
@@ -93,12 +93,11 @@ class Generator(use_metaclass(CachedMetaClass, IterableWrapper, GeneratorMixin))
         if name not in ['start_pos', 'end_pos', 'parent', 'get_imports',
                         'doc', 'docstr', 'get_parent_until',
                         'get_code', 'subscopes']:
-            raise AttributeError("Accessing %s of %s is not allowed."
-                                 % (self, name))
+            raise AttributeError("Accessing {0!s} of {1!s} is not allowed.".format(self, name))
         return getattr(self.func, name)
 
     def __repr__(self):
-        return "<%s of %s>" % (type(self).__name__, self.func)
+        return "<{0!s} of {1!s}>".format(type(self).__name__, self.func)
 
 
 class GeneratorMethod(IterableWrapper):
@@ -152,7 +151,7 @@ class Comprehension(IterableWrapper):
         return [self._evaluator.eval_element(self.eval_node())[index]]
 
     def __repr__(self):
-        return "<e%s of %s>" % (type(self).__name__, self._atom)
+        return "<e{0!s} of {1!s}>".format(type(self).__name__, self._atom)
 
 
 class ArrayMixin(object):
@@ -249,7 +248,7 @@ class Array(IterableWrapper, ArrayMixin):
                             and mixed_index == k.obj:
                         for value in values:
                             return self._evaluator.eval_element(value)
-            raise KeyError('No key found in dictionary %s.' % self)
+            raise KeyError('No key found in dictionary {0!s}.'.format(self))
 
         # Can raise an IndexError
         return self._evaluator.eval_element(self._items()[mixed_index])
@@ -267,7 +266,7 @@ class Array(IterableWrapper, ArrayMixin):
     def __getattr__(self, name):
         if name not in ['start_pos', 'get_only_subelement', 'parent',
                         'get_parent_until', 'items']:
-            raise AttributeError('Strange access on %s: %s.' % (self, name))
+            raise AttributeError('Strange access on {0!s}: {1!s}.'.format(self, name))
         return getattr(self.atom, name)
 
     def _values(self):
@@ -305,7 +304,7 @@ class Array(IterableWrapper, ArrayMixin):
         return iter(self._items())
 
     def __repr__(self):
-        return "<%s of %s>" % (type(self).__name__, self.atom)
+        return "<{0!s} of {1!s}>".format(type(self).__name__, self.atom)
 
 
 class _FakeArray(Array):

--- a/jedi/evaluate/param.py
+++ b/jedi/evaluate/param.py
@@ -151,7 +151,7 @@ class Arguments(tree.Base):
         return [self._evaluator.eval_element(el) for stars, el in self._split()]
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self.argument_node)
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, self.argument_node)
 
     def get_calling_var_args(self):
         if tree.is_node(self.argument_node, 'arglist', 'argument') \
@@ -248,8 +248,7 @@ def get_params(evaluator, func, var_args):
 
             if k in keys_used:
                 had_multiple_value_error = True
-                m = ("TypeError: %s() got multiple values for keyword argument '%s'."
-                     % (func.name, k))
+                m = ("TypeError: {0!s}() got multiple values for keyword argument '{1!s}'.".format(func.name, k))
                 calling_va = _get_calling_var_args(evaluator, var_args)
                 if calling_va is not None:
                     analysis.add(evaluator, 'type-error-multiple-values',
@@ -318,8 +317,7 @@ def get_params(evaluator, func, var_args):
                                  calling_va, message=m)
 
     for key, va_values in non_matching_keys.items():
-        m = "TypeError: %s() got an unexpected keyword argument '%s'." \
-            % (func.name, key)
+        m = "TypeError: {0!s}() got an unexpected keyword argument '{1!s}'.".format(func.name, key)
         for value in va_values:
             analysis.add(evaluator, 'type-error-keyword-argument', value.parent, message=m)
 
@@ -359,11 +357,10 @@ def _iterate_star_args(evaluator, array, input_node, func=None):
         for field_stmt in array.iter_content():
             yield iterable.AlreadyEvaluated([field_stmt])
     elif isinstance(array, Instance) and array.name.get_code() == 'tuple':
-        debug.warning('Ignored a tuple *args input %s' % array)
+        debug.warning('Ignored a tuple *args input {0!s}'.format(array))
     else:
         if func is not None:
-            m = "TypeError: %s() argument after * must be a sequence, not %s" \
-                % (func.name.value, array)
+            m = "TypeError: {0!s}() argument after * must be a sequence, not {1!s}".format(func.name.value, array)
             analysis.add(evaluator, 'type-error-star', input_node, message=m)
 
 
@@ -386,8 +383,7 @@ def _star_star_dict(evaluator, array, input_node, func):
 
     else:
         if func is not None:
-            m = "TypeError: %s argument after ** must be a mapping, not %s" \
-                % (func.name.value, array)
+            m = "TypeError: {0!s} argument after ** must be a mapping, not {1!s}".format(func.name.value, array)
             analysis.add(evaluator, 'type-error-star-star', input_node, message=m)
     return dict(dct)
 
@@ -398,6 +394,5 @@ def _error_argument_count(func, actual_count):
     if default_arguments == 0:
         before = 'exactly '
     else:
-        before = 'from %s to ' % (len(func.params) - default_arguments)
-    return ('TypeError: %s() takes %s%s arguments (%s given).'
-            % (func.name, before, len(func.params), actual_count))
+        before = 'from {0!s} to '.format((len(func.params) - default_arguments))
+    return ('TypeError: {0!s}() takes {1!s}{2!s} arguments ({3!s} given).'.format(func.name, before, len(func.params), actual_count))

--- a/jedi/evaluate/representation.py
+++ b/jedi/evaluate/representation.py
@@ -220,15 +220,14 @@ class Instance(use_metaclass(CachedMetaClass, Executed)):
     def __getattr__(self, name):
         if name not in ['start_pos', 'end_pos', 'get_imports', 'type',
                         'doc', 'raw_doc']:
-            raise AttributeError("Instance %s: Don't touch this (%s)!"
-                                 % (self, name))
+            raise AttributeError("Instance {0!s}: Don't touch this ({1!s})!".format(self, name))
         return getattr(self.base, name)
 
     def __repr__(self):
         dec = ''
         if self.decorates is not None:
             dec = " decorates " + repr(self.decorates)
-        return "<e%s of %s(%s)%s>" % (type(self).__name__, self.base,
+        return "<e{0!s} of {1!s}({2!s}){3!s}>".format(type(self).__name__, self.base,
                                       self.var_args, dec)
 
 
@@ -364,7 +363,7 @@ class InstanceElement(use_metaclass(CachedMetaClass, tree.Base)):
             return Function.py__call__(self, evaluator, params)
 
     def __repr__(self):
-        return "<%s of %s>" % (type(self).__name__, self.var)
+        return "<{0!s} of {1!s}>".format(type(self).__name__, self.var)
 
 
 class Wrapper(tree.Base):
@@ -473,11 +472,11 @@ class Class(use_metaclass(CachedMetaClass, Wrapper)):
         if name not in ['start_pos', 'end_pos', 'parent', 'raw_doc',
                         'doc', 'get_imports', 'get_parent_until', 'get_code',
                         'subscopes', 'names_dict', 'type']:
-            raise AttributeError("Don't touch this: %s of %s !" % (name, self))
+            raise AttributeError("Don't touch this: {0!s} of {1!s} !".format(name, self))
         return getattr(self.base, name)
 
     def __repr__(self):
-        return "<e%s of %s>" % (type(self).__name__, self.base)
+        return "<e{0!s} of {1!s}>".format(type(self).__name__, self.base)
 
 
 class Function(use_metaclass(CachedMetaClass, Wrapper)):
@@ -566,7 +565,7 @@ class Function(use_metaclass(CachedMetaClass, Wrapper)):
         dec = ''
         if self.decorates is not None:
             dec = " decorates " + repr(self.decorates)
-        return "<e%s of %s%s>" % (type(self).__name__, self.base_func, dec)
+        return "<e{0!s} of {1!s}{2!s}>".format(type(self).__name__, self.base_func, dec)
 
 
 class LambdaWrapper(Function):
@@ -662,7 +661,7 @@ class FunctionExecution(Executed):
 
     def __getattr__(self, name):
         if name not in ['start_pos', 'end_pos', 'imports', 'name', 'type']:
-            raise AttributeError('Tried to access %s: %s. Why?' % (name, self))
+            raise AttributeError('Tried to access {0!s}: {1!s}. Why?'.format(name, self))
         return getattr(self.base, name)
 
     def _scope_copy(self, scope):
@@ -694,7 +693,7 @@ class FunctionExecution(Executed):
         return tree.Scope._search_in_scope(self, tree.Scope)
 
     def __repr__(self):
-        return "<%s of %s>" % (type(self).__name__, self.base)
+        return "<{0!s} of {1!s}>".format(type(self).__name__, self.base)
 
 
 class GlobalName(helpers.FakeName):
@@ -854,4 +853,4 @@ class ModuleWrapper(use_metaclass(CachedMetaClass, tree.Module, Wrapper)):
         return getattr(self._module, name)
 
     def __repr__(self):
-        return "<%s: %s>" % (type(self).__name__, self._module)
+        return "<{0!s}: {1!s}>".format(type(self).__name__, self._module)

--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -35,7 +35,7 @@ def _get_venv_sitepackages(venv):
     if os.name == 'nt':
         p = os.path.join(venv, 'lib', 'site-packages')
     else:
-        p = os.path.join(venv, 'lib', 'python%d.%d' % sys.version_info[:2],
+        p = os.path.join(venv, 'lib', 'python{0:d}.{1:d}'.format(*sys.version_info[:2]),
                          'site-packages')
     return p
 

--- a/jedi/parser/__init__.py
+++ b/jedi/parser/__init__.py
@@ -347,7 +347,7 @@ class Parser(object):
         self.syntax_errors.append(ParserSyntaxError(message, position))
 
     def __repr__(self):
-        return "<%s: %s>" % (type(self).__name__, self.module)
+        return "<{0!s}: {1!s}>".format(type(self).__name__, self.module)
 
     def remove_last_newline(self):
         """

--- a/jedi/parser/fast.py
+++ b/jedi/parser/fast.py
@@ -49,7 +49,7 @@ class FastModule(tree.Module):
         return [e for m in self.modules for e in m.error_statement_stacks]
 
     def __repr__(self):
-        return "<fast.%s: %s@%s-%s>" % (type(self).__name__, self.name,
+        return "<fast.{0!s}: {1!s}@{2!s}-{3!s}>".format(type(self).__name__, self.name,
                                         self.start_pos[0], self.end_pos[0])
 
     # To avoid issues with with the `parser.Parser`, we need setters that do
@@ -149,10 +149,10 @@ class ParserNode(object):
     def __repr__(self):
         module = self.parser.module
         try:
-            return '<%s: %s-%s>' % (type(self).__name__, module.start_pos, module.end_pos)
+            return '<{0!s}: {1!s}-{2!s}>'.format(type(self).__name__, module.start_pos, module.end_pos)
         except IndexError:
             # There's no module yet.
-            return '<%s: empty>' % type(self).__name__
+            return '<{0!s}: empty>'.format(type(self).__name__)
 
     def reset_node(self):
         """
@@ -231,8 +231,7 @@ class ParserNode(object):
 class FastParser(use_metaclass(CachedFastParser)):
     _FLOWS_NEED_SPACE = 'if', 'elif', 'while', 'with', 'except', 'for'
     _FLOWS_NEED_COLON = 'else', 'try', 'except', 'finally'
-    _keyword_re = re.compile('^[ \t]*(def |class |@|(?:%s)|(?:%s)\s*:)'
-                             % ('|'.join(_FLOWS_NEED_SPACE),
+    _keyword_re = re.compile('^[ \t]*(def |class |@|(?:{0!s})|(?:{1!s})\s*:)'.format('|'.join(_FLOWS_NEED_SPACE),
                                 '|'.join(_FLOWS_NEED_COLON)))
 
     def __init__(self, grammar, source, module_path=None):
@@ -412,8 +411,7 @@ class FastParser(use_metaclass(CachedFastParser)):
         self.current_node = self.current_node.parent_until_indent()
         self.current_node.close()
 
-        debug.dbg('Parsed %s, with %s parsers in %s splits.'
-                  % (self.module_path, self.number_parsers_used,
+        debug.dbg('Parsed {0!s}, with {1!s} parsers in {2!s} splits.'.format(self.module_path, self.number_parsers_used,
                      self.number_of_splits))
 
     def _get_node(self, source, parser_code, line_offset, nodes):

--- a/jedi/parser/pgen2/parse.py
+++ b/jedi/parser/pgen2/parse.py
@@ -22,8 +22,7 @@ class ParseError(Exception):
     """Exception to signal the parser is stuck."""
 
     def __init__(self, msg, type, value, start_pos):
-        Exception.__init__(self, "%s: type=%r, value=%r, start_pos=%r" %
-                           (msg, tokenize.tok_name[type], value, start_pos))
+        Exception.__init__(self, "{0!s}: type={1!r}, value={2!r}, start_pos={3!r}".format(msg, tokenize.tok_name[type], value, start_pos))
         self.msg = msg
         self.type = type
         self.value = value

--- a/jedi/parser/pgen2/pgen.py
+++ b/jedi/parser/pgen2/pgen.py
@@ -126,7 +126,7 @@ class ParserGenerator(object):
                 if label in self.first:
                     fset = self.first[label]
                     if fset is None:
-                        raise ValueError("recursion for rule %r" % name)
+                        raise ValueError("recursion for rule {0!r}".format(name))
                 else:
                     self.calcfirst(label)
                     fset = self.first[label]
@@ -220,16 +220,16 @@ class ParserGenerator(object):
                     j = len(todo)
                     todo.append(next)
                 if label is None:
-                    print("    -> %d" % j)
+                    print("    -> {0:d}".format(j))
                 else:
-                    print("    %s -> %d" % (label, j))
+                    print("    {0!s} -> {1:d}".format(label, j))
 
     def dump_dfa(self, name, dfa):
         print("Dump of DFA for", name)
         for i, state in enumerate(dfa):
             print("  State", i, state.isfinal and "(final)" or "")
             for label, next in state.arcs.items():
-                print("    %s -> %d" % (label, dfa.index(next)))
+                print("    {0!s} -> {1:d}".format(label, dfa.index(next)))
 
     def simplify_dfa(self, dfa):
         # This is not theoretically optimal, but works well enough.

--- a/jedi/parser/tree.py
+++ b/jedi/parser/tree.py
@@ -225,7 +225,7 @@ class Leaf(Base):
 
     @utf8_repr
     def __repr__(self):
-        return "<%s: %s>" % (type(self).__name__, self.value)
+        return "<{0!s}: {1!s}>".format(type(self).__name__, self.value)
 
 
 class LeafWithNewLines(Leaf):
@@ -250,7 +250,7 @@ class LeafWithNewLines(Leaf):
 
     @utf8_repr
     def __repr__(self):
-        return "<%s: %r>" % (type(self).__name__, self.value)
+        return "<{0!s}: {1!r}>".format(type(self).__name__, self.value)
 
 class Whitespace(LeafWithNewLines):
     """Contains NEWLINE and ENDMARKER tokens."""
@@ -273,7 +273,7 @@ class Name(Leaf):
         return self.value
 
     def __repr__(self):
-        return "<%s: %s@%s,%s>" % (type(self).__name__, self.value,
+        return "<{0!s}: {1!s}@{2!s},{3!s}>".format(type(self).__name__, self.value,
                                    self.start_pos[0], self.start_pos[1])
 
     def get_definition(self):
@@ -472,8 +472,7 @@ class BaseNode(Base):
         code = self.get_code().replace('\n', ' ')
         if not is_py3:
             code = code.encode(encoding, 'replace')
-        return "<%s: %s@%s,%s>" % \
-            (type(self).__name__, code, self.start_pos[0], self.start_pos[1])
+        return "<{0!s}: {1!s}@{2!s},{3!s}>".format(type(self).__name__, code, self.start_pos[0], self.start_pos[1])
 
 
 class Node(BaseNode):
@@ -493,7 +492,7 @@ class Node(BaseNode):
         self.type = type
 
     def __repr__(self):
-        return "%s(%s, %r)" % (self.__class__.__name__, self.type, self.children)
+        return "{0!s}({1!s}, {2!r})".format(self.__class__.__name__, self.type, self.children)
 
 
 class IsScopeMeta(type):
@@ -569,7 +568,7 @@ class Scope(BaseNode, DocstringMixin):
             except AttributeError:
                 name = self.command
 
-        return "<%s: %s@%s-%s>" % (type(self).__name__, name,
+        return "<{0!s}: {1!s}@{2!s}-{3!s}>".format(type(self).__name__, name,
                                    self.start_pos[0], self.end_pos[0])
 
     def walk(self):
@@ -615,7 +614,7 @@ class Module(Scope):
             string = ''  # no path -> empty name
         else:
             sep = (re.escape(os.path.sep),) * 2
-            r = re.search(r'([^%s]*?)(%s__init__)?(\.py|\.so)?$' % sep, self.path)
+            r = re.search(r'([^{0!s}]*?)({1!s}__init__)?(\.py|\.so)?$'.format(*sep), self.path)
             # Remove PEP 3149 names
             string = re.sub('\.[a-z]+-\d{2}[mud]{0,3}$', '', r.group(1))
         # Positions are not real, but a module starts at (1, 0)
@@ -699,7 +698,7 @@ class Class(ClassOrFunc):
         docstr = self.raw_doc
         for sub in self.subscopes:
             if str(sub.name) == '__init__':
-                return '%s\n\n%s' % (
+                return '{0!s}\n\n{1!s}'.format(
                     sub.get_call_signature(func_name=self.name), docstr)
         return docstr
 
@@ -803,7 +802,7 @@ class Function(ClassOrFunc):
     def doc(self):
         """ Return a document string including call signature. """
         docstr = self.raw_doc
-        return '%s\n\n%s' % (self.get_call_signature(), docstr)
+        return '{0!s}\n\n{1!s}'.format(self.get_call_signature(), docstr)
 
 
 class Lambda(Function):
@@ -831,7 +830,7 @@ class Lambda(Function):
         return []
 
     def __repr__(self):
-        return "<%s@%s>" % (self.__class__.__name__, self.start_pos)
+        return "<{0!s}@{1!s}>".format(self.__class__.__name__, self.start_pos)
 
 
 class Flow(BaseNode):
@@ -1200,8 +1199,8 @@ class Param(BaseNode):
         return self.get_parent_until(IsScope)
 
     def __repr__(self):
-        default = '' if self.default is None else '=%s' % self.default
-        return '<%s: %s>' % (type(self).__name__, str(self._tfpdef()) + default)
+        default = '' if self.default is None else '={0!s}'.format(self.default)
+        return '<{0!s}: {1!s}>'.format(type(self).__name__, str(self._tfpdef()) + default)
 
 
 class CompFor(BaseNode):

--- a/jedi/refactoring.py
+++ b/jedi/refactoring.py
@@ -146,11 +146,11 @@ def extract(script, new_name):
             close_brackets = [')', ']', '}']
             if '\n' in text and not (text[0] in open_brackets and text[-1] ==
                                      close_brackets[open_brackets.index(text[0])]):
-                text = '(%s)' % text
+                text = '({0!s})'.format(text)
 
             # add new line before statement
             indent = user_stmt.start_pos[1]
-            new = "%s%s = %s" % (' ' * indent, new_name, text)
+            new = "{0!s}{1!s} = {2!s}".format(' ' * indent, new_name, text)
             new_lines.insert(line_index, new)
     dct[script.path] = script.path, old_lines, new_lines
     return Refactoring(dct)
@@ -185,7 +185,7 @@ def inline(script):
         if expression_list and isinstance(expression_list[0], pr.Array):
             arr = expression_list[0]
             if replace_str[0] not in ['(', '[', '{'] and len(arr) > 1:
-                replace_str = '(%s)' % replace_str
+                replace_str = '({0!s})'.format(replace_str)
 
         # if it's the only assignment, remove the statement
         if len(stmt.get_defined_names()) == 1:

--- a/scripts/memory_check.py
+++ b/scripts/memory_check.py
@@ -42,11 +42,11 @@ def main(mods):
     for mod in mods:
         elapsed, used = profile_preload(mod)
         if used > 0:
-            print('%8.2f | %8d | %s' % (elapsed, used, mod))
+            print('{0:8.2f} | {1:8d} | {2!s}'.format(elapsed, used, mod))
     print('------------------------------')
     elapsed = time.time() - t0
     used = used_memory() - baseline
-    print('%8.2f | %8d | %s' % (elapsed, used, 'Total'))
+    print('{0:8.2f} | {1:8d} | {2!s}'.format(elapsed, used, 'Total'))
 
 
 if __name__ == '__main__':

--- a/scripts/profile.py
+++ b/scripts/profile.py
@@ -25,7 +25,7 @@ import jedi
 def run(code, index):
     start = time.time()
     result = jedi.Script(code).completions()
-    print('Used %ss for the %sth run.' % (time.time() - start, index + 1))
+    print('Used {0!s}s for the {1!s}th run.'.format(time.time() - start, index + 1))
     return result
 
 

--- a/scripts/wx_check.py
+++ b/scripts/wx_check.py
@@ -41,16 +41,16 @@ wx_core = urllib2.urlopen(uri).read()
 
 def run():
     start = time.time()
-    print('Process Memory before: %skB' % process_memory())
+    print('Process Memory before: {0!s}kB'.format(process_memory()))
     # After this the module should be cached.
     # Need to invent a path so that it's really cached.
     jedi.Script(wx_core, path='foobar.py').completions()
 
     gc.collect()  # make sure that it's all fair and the gc did its job.
-    print('Process Memory after: %skB' % process_memory())
+    print('Process Memory after: {0!s}kB'.format(process_memory()))
 
     print(objgraph.most_common_types(limit=50))
-    print('\nIt took %s seconds to parse the file.' % (time.time() - start))
+    print('\nIt took {0!s} seconds to parse the file.'.format((time.time() - start)))
 
 
 print('First pass')

--- a/sith.py
+++ b/sith.py
@@ -80,7 +80,7 @@ class SourceFinder(object):
 class TestCase(object):
     def __init__(self, operation, path, line, column, traceback=None):
         if operation not in self.operations:
-            raise ValueError("%s is not a valid operation" % operation)
+            raise ValueError("{0!s} is not a valid operation".format(operation))
 
         # Set other attributes
         self.operation = operation
@@ -150,7 +150,7 @@ class TestCase(object):
         print(prefix, '   ', ' ' * (column + len(str(lineno))), '^')
 
     def show_operation(self):
-        print("%s:\n" % self.operation.capitalize())
+        print("{0!s}:\n".format(self.operation.capitalize()))
         if self.operation == 'completions':
             self.show_completions()
         else:
@@ -201,7 +201,7 @@ def main(arguments):
         for _ in range(int(arguments['--maxtries'])):
             t = TestCase.generate(arguments['<path>'] or '.')
             if arguments['-s']:
-                print('%s %s %s %s ' % (t.operation, t.path, t.line, t.column))
+                print('{0!s} {1!s} {2!s} {3!s} '.format(t.operation, t.path, t.line, t.column))
                 sys.stdout.flush()
             else:
                 print('.', end='')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,7 +60,7 @@ def pytest_generate_tests(metafunc):
         if thirdparty:
             cases.extend(run.collect_dir_tests(
                 os.path.join(base_dir, 'thirdparty'), test_files, True))
-        ids = ["%s:%s" % (c.module_name, c.line_nr_test) for c in cases]
+        ids = ["{0!s}:{1!s}".format(c.module_name, c.line_nr_test) for c in cases]
         metafunc.parametrize('case', cases, ids=ids)
 
     if 'refactor_case' in metafunc.fixturenames:
@@ -112,7 +112,7 @@ class StaticAnalysisCase(object):
         compare_cb(self, analysis, self.collect_comparison())
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, os.path.basename(self._path))
+        return "<{0!s}: {1!s}>".format(self.__class__.__name__, os.path.basename(self._path))
 
 
 @pytest.fixture()

--- a/test/refactor.py
+++ b/test/refactor.py
@@ -57,7 +57,7 @@ class RefactoringCase(object):
         return self.run() == self.desired
 
     def __repr__(self):
-        return '<%s: %s:%s>' % (self.__class__.__name__,
+        return '<{0!s}: {1!s}:{2!s}>'.format(self.__class__.__name__,
                                 self.name, self.line_nr - 1)
 
 

--- a/test/run.py
+++ b/test/run.py
@@ -147,7 +147,7 @@ class IntegrationTestCase(object):
         return self.line_nr - 1
 
     def __repr__(self):
-        return '<%s: %s:%s:%s>' % (self.__class__.__name__, self.module_name,
+        return '<{0!s}: {1!s}:{2!s}:{3!s}>'.format(self.__class__.__name__, self.module_name,
                                    self.line_nr_test, self.line.rstrip())
 
     def script(self):
@@ -189,14 +189,12 @@ class IntegrationTestCase(object):
                 try:
                     should_be |= defs(self.line_nr - 1, end + correct_start)
                 except Exception:
-                    print('could not resolve %s indent %s'
-                          % (self.line_nr - 1, end))
+                    print('could not resolve {0!s} indent {1!s}'.format(self.line_nr - 1, end))
                     raise
             # because the objects have different ids, `repr`, then compare.
             should = set(comparison(r) for r in should_be)
             if len(should) < number:
-                raise Exception('Solution @%s not right, too few test results: %s'
-                                % (self.line_nr - 1, should))
+                raise Exception('Solution @{0!s} not right, too few test results: {1!s}'.format(self.line_nr - 1, should))
             return should
 
         script = self.script()
@@ -287,7 +285,7 @@ def collect_dir_tests(base_dir, test_files, check_thirdparty=False):
                     # It looks like: completion/thirdparty/pylab_.py
                     __import__(lib)
                 except ImportError:
-                    skip = 'Thirdparty-Library %s not found.' % lib
+                    skip = 'Thirdparty-Library {0!s} not found.'.format(lib)
 
             path = os.path.join(base_dir, f_name)
 
@@ -360,14 +358,13 @@ if __name__ == '__main__':
     def file_change(current, tests, fails):
         if current is not None:
             current = os.path.basename(current)
-        print('%s \t\t %s tests and %s fails.' % (current, tests, fails))
+        print('{0!s} \t\t {1!s} tests and {2!s} fails.'.format(current, tests, fails))
 
     def report(case, actual, desired):
         if actual == desired:
             return 0
         else:
-            print("\ttest fail @%d, actual = %s, desired = %s"
-                  % (case.line_nr - 1, actual, desired))
+            print("\ttest fail @{0:d}, actual = {1!s}, desired = {2!s}".format(case.line_nr - 1, actual, desired))
             return 1
 
     import traceback
@@ -385,7 +382,7 @@ if __name__ == '__main__':
                 fails += 1
         except Exception:
             traceback.print_exc()
-            print("\ttest fail @%d" % (c.line_nr - 1))
+            print("\ttest fail @{0:d}".format((c.line_nr - 1)))
             tests_fail += 1
             fails += 1
             if arguments['--pdb']:
@@ -396,8 +393,7 @@ if __name__ == '__main__':
 
     file_change(current, count, fails)
 
-    print('\nSummary: (%s fails of %s tests) in %.3fs'
-          % (tests_fail, len(cases), time.time() - t_start))
+    print('\nSummary: ({0!s} fails of {1!s} tests) in {2:.3f}s'.format(tests_fail, len(cases), time.time() - t_start))
     for s in summary:
         print(s)
 

--- a/test/static_analysis/attribute_error.py
+++ b/test/static_analysis/attribute_error.py
@@ -95,7 +95,7 @@ def func():
 # operators
 # -----------------
 
-string = '%s %s' % (1, 2)
+string = '{0!s} {1!s}'.format(1, 2)
 
 # Shouldn't raise an error, because `string` is really just a string, not an
 # array or something.

--- a/test/test_evaluate/test_extension.py
+++ b/test/test_evaluate/test_extension.py
@@ -20,7 +20,7 @@ def test_call_signatures_extension():
     else:
         func = 'dlopen'
         params = 2
-    s = jedi.Script('import _ctypes; _ctypes.%s(' % (func,))
+    s = jedi.Script('import _ctypes; _ctypes.{0!s}('.format(func))
     sigs = s.call_signatures()
     assert len(sigs) == 1
     assert len(sigs[0].params) == params

--- a/test/test_evaluate/test_namespace_package.py
+++ b/test/test_evaluate/test_namespace_package.py
@@ -24,7 +24,7 @@ def test_namespace_package():
         for source, solution in tests.items():
             ass = jedi.Script(source).goto_assignments()
             assert len(ass) == 1
-            assert ass[0].description == "foo = '%s'" % solution
+            assert ass[0].description == "foo = '{0!s}'".format(solution)
 
         # completion
         completions = jedi.Script('from pkg import ').completions()
@@ -47,7 +47,7 @@ def test_namespace_package():
             for c in jedi.Script(source + '; x.').completions():
                 if c.name == 'foo':
                     completion = c
-            solution = "statement: foo = '%s'" % solution
+            solution = "statement: foo = '{0!s}'".format(solution)
             assert completion.description == solution
 
     finally:

--- a/test/test_evaluate/test_pyc.py
+++ b/test/test_evaluate/test_pyc.py
@@ -40,7 +40,7 @@ def generate_pyc():
         # directory and rename them to remove ".cpython-%s%d"
         # see: http://stackoverflow.com/questions/11648440/python-does-not-detect-pyc-files
         for f in os.listdir("dummy_package/__pycache__"):
-            dst = f.replace('.cpython-%s%s' % sys.version_info[:2], "")
+            dst = f.replace('.cpython-{0!s}{1!s}'.format(*sys.version_info[:2]), "")
             dst = os.path.join("dummy_package", dst)
             shutil.copy(os.path.join("dummy_package/__pycache__", f), dst)
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -14,10 +14,10 @@ def assert_case_equal(case, actual, desired):
     due to py.test magic, let's format the message by hand.
     """
     assert actual == desired, """
-Test %r failed.
-actual  = %s
-desired = %s
-""" % (case, actual, desired)
+Test {0!r} failed.
+actual  = {1!s}
+desired = {2!s}
+""".format(case, actual, desired)
 
 
 def assert_static_analysis(case, actual, desired):
@@ -25,10 +25,10 @@ def assert_static_analysis(case, actual, desired):
     a = set(actual)
     d = set(desired)
     assert actual == desired, """
-Test %r failed.
-not raised  = %s
-unspecified = %s
-""" % (case, sorted(d - a), sorted(a - d))
+Test {0!r} failed.
+not raised  = {1!s}
+unspecified = {2!s}
+""".format(case, sorted(d - a), sorted(a - d))
 
 
 def test_completion(case, monkeypatch):

--- a/test/test_integration_stdlib.py
+++ b/test/test_integration_stdlib.py
@@ -19,7 +19,7 @@ def test_namedtuple_str(letter, expected):
     source = "import collections\n" + \
              "Person = collections.namedtuple('Person', 'name smart')\n" + \
              "dave = Person('Dave', False)\n" + \
-             "dave.%s" % letter
+             "dave.{0!s}".format(letter)
     result = Script(source).completions()
     completions = set(r.name for r in result)
     if is_py26:

--- a/test/test_parser/test_get_code.py
+++ b/test/test_parser/test_get_code.py
@@ -33,7 +33,7 @@ def diff_code_assert(a, b, n=4):
             n=n,
             lineterm=""
         ))
-        assert False, "Code does not match:\n%s\n\ncreated code:\n%s" % (
+        assert False, "Code does not match:\n{0!s}\n\ncreated code:\n{1!s}".format(
             diff,
             b
         )

--- a/test/test_parser/test_parser.py
+++ b/test/test_parser/test_parser.py
@@ -190,7 +190,7 @@ def test_param_splitting():
     """
     def check(src, result):
         # Python 2 tuple params should be ignored for now.
-        grammar = load_grammar('grammar%s.%s' % sys.version_info[:2])
+        grammar = load_grammar('grammar{0!s}.{1!s}'.format(*sys.version_info[:2]))
         m = Parser(grammar, u(src)).module
         if is_py3:
             assert not m.subscopes

--- a/test/test_parser/test_tokenize.py
+++ b/test/test_parser/test_tokenize.py
@@ -108,7 +108,7 @@ class TokenTest(unittest.TestCase):
         ]
 
         for s in string_tokens:
-            parsed = Parser(load_grammar(), u('''a = %s\n''' % s))
+            parsed = Parser(load_grammar(), u('''a = {0!s}\n'''.format(s)))
             simple_stmt = parsed.module.children[0]
             expr_stmt = simple_stmt.children[0]
             assert len(expr_stmt.children) == 3


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:jedi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:jedi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
